### PR TITLE
Export DockerRequirement and always include input/output dicts

### DIFF
--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -120,6 +120,14 @@ class CommandLineTool(object):
             for k, v in self.namespaces.__dict__.items():
                 if '$' not in v:
                     cwl_tool[self.namespaces.name][k] = v
+
+        # Add requirements.
+        requirements = {}
+        for requirement in self.requirements:
+            requirement.add(requirements)
+
+        if requirements:
+            cwl_tool['requirements'] = requirements
         
         # Write CWL file in YAML
         if outfile is None:
@@ -365,6 +373,13 @@ class Requirement(object):
         '''
         self.req_class = req_class
 
+    def add(self, tool):
+        tool[self.req_class] = self._to_dict()
+
+    def _to_dict(self):
+        raise NotImplementedError("Requirement subclass {} not fully implemented".format(
+            self.req_class))
+
 
 class InlineJavascriptReq(Requirement):
     '''
@@ -409,6 +424,16 @@ class DockerRequirement(Requirement):
         self.dockerImport = docker_import
         self.dockerImageId = docker_image_id
         self.dockerOutputDir = docker_output_dir
+
+    def _to_dict(self):
+        """
+        Add this requirement to a dictionary description of a 
+        tool generated in an export method.
+
+        """
+        return {p:v for p,v in vars(self).items() if p.startswith('docker') and v is not None}
+
+
 
 
 class Namespaces(object):

--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -102,16 +102,14 @@ class CommandLineTool(object):
         if self.doc:
             cwl_tool['doc'] = literal(self.doc)
         # Add Inputs
-        if self.inputs:
-            cwl_tool['inputs'] = {}
-            for in_param in self.inputs:
-                cwl_tool['inputs'][in_param.id] = in_param.get_dict()
+        cwl_tool['inputs'] = {}
+        for in_param in self.inputs:
+            cwl_tool['inputs'][in_param.id] = in_param.get_dict()
 
         # Add Outputs
-        if self.outputs:
-            cwl_tool['outputs'] = {}
-            for out_param in self.outputs:
-                cwl_tool['outputs'][out_param.id] = out_param.get_dict()
+        cwl_tool['outputs'] = {}
+        for out_param in self.outputs:
+            cwl_tool['outputs'][out_param.id] = out_param.get_dict()
 
         # If metadata are present in the description
         if getattr(self, 'metadata', None):

--- a/test/test_unit_cwlgen.py
+++ b/test/test_unit_cwlgen.py
@@ -208,6 +208,12 @@ class TestDockerRequirement(unittest.TestCase):
         self.assertEqual(self.dock_req.dockerImageId, 'id')
         self.assertEqual(self.dock_req.dockerOutputDir, 'dir')
 
+    def test_export(self):
+        d = self.dock_req._to_dict()
+        assert d == dict(dockerPull='pull', dockerLoad='load',\
+                         dockerFile='file', dockerImport='import',\
+                         dockerImageId='id', dockerOutputDir='dir')
+
 
 ###########  Main  ###########
 


### PR DESCRIPTION
This adds DockerRequirement's, which currently aren't being propagated to the output in the export method.

It also modifies the export method to always include input and output dictionaries, even if they are empty.  The cwl-runner tool seems to require this; I'm not sure if it's in the spec.