### PR TITLE
Adds export of arguments in command line tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 test/__pycache__
 cwlgen/__pycache__
 doc/build/
+.ropeproject/
+build/
+cwlgen.egg*
+dist/

--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -297,8 +297,8 @@ class CommandLineBinding(object):
     Describes how the handle an input or an argument.
     '''
 
-    def __init__(self, load_contents=False, position=None, prefix=None, separate=False,
-                 item_separator=None, value_from=None, shell_quote=False):
+    def __init__(self, load_contents=False, position=None, prefix=None, separate=True,
+                 item_separator=None, value_from=None, shell_quote=True):
         '''
         :param load_contents: Read up to the fist 64 KiB of text from the file and
                               place it in the "contents" field of the file object
@@ -331,7 +331,7 @@ class CommandLineBinding(object):
         :return: dictionnary of the object
         :rtype: DICT
         '''
-        dict_binding = {k: v for k, v in vars(self).items() if v is not None and v is not False}
+        dict_binding = {k: v for k, v in vars(self).items() if v is not None}
         return dict_binding
 
 

--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -101,6 +101,10 @@ class CommandLineTool(object):
         # Treat doc for multiline writting
         if self.doc:
             cwl_tool['doc'] = literal(self.doc)
+
+        # Add Arguments
+        cwl_tool['arguments'] = [in_arg.get_dict() for in_arg in self.arguments]
+
         # Add Inputs
         cwl_tool['inputs'] = {}
         for in_param in self.inputs:
@@ -128,7 +132,7 @@ class CommandLineTool(object):
 
         if requirements:
             cwl_tool['requirements'] = requirements
-        
+
         # Write CWL file in YAML
         if outfile is None:
             six.print_(CWL_SHEBANG, "\n", sep='')
@@ -427,7 +431,7 @@ class DockerRequirement(Requirement):
 
     def _to_dict(self):
         """
-        Add this requirement to a dictionary description of a 
+        Add this requirement to a dictionary description of a
         tool generated in an export method.
 
         """


### PR DESCRIPTION
The arguments of CommandLineTools  were not exported to the CWL files, this pull request fixes that. 
I have also realized that the `CommandLineBinding` was not properly exporting the `separate` and `shellQuote` fields because it was automatically eliminating `false` parameters, whereas the default for these fields should be `true`. I have removed that small optimization and now everything works as expected.
