### PR TITLE
Working on streamlining process of creating a new workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ doc/build/
 build/
 cwlgen.egg*
 dist/
+*.pyc

--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -16,19 +16,13 @@ import six
 from .version import __version__
 
 from .utils import *
+from .elements import Parameter, CWL_VERSIONS
+from .workflow import Workflow, File
+from .import_cwl import parse_cwl
 
 logging.basicConfig(level=logging.INFO)
 LOGGER = logging.getLogger(__name__)
 
-#  Constant(s)  ------------------------------
-
-CWL_SHEBANG = "#!/usr/bin/env cwl-runner"
-CWL_VERSIONS = ['draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3',
-                'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1',
-                'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0', None]
-DEF_VERSION = 'v1.0'
-CWL_TYPE = ['null', 'boolean', 'int', 'long', 'float', 'double', 'string', 'File',
-            'Directory', None]
 
 #  Function(s)  ------------------------------
 
@@ -43,7 +37,7 @@ class CommandLineTool(object):
     __CLASS__ = 'CommandLineTool'
 
     def __init__(self, tool_id=None, base_command=None, label=None, doc=None,
-                 cwl_version=None, stdin=None, stderr=None, stdout=None):
+                 cwl_version=None, stdin=None, stderr=None, stdout=None, path=None):
         '''
         :param tool_id: unique identifier for this tool
         :type tool_id: STRING
@@ -87,6 +81,7 @@ class CommandLineTool(object):
         self.successCodes = []
         self.temporaryFailCodes = []
         self.permanentFailCodes = []
+        self._path = path
         self.namespaces = Namespaces()
 
     def export(self, outfile=None):
@@ -144,58 +139,6 @@ class CommandLineTool(object):
             out_write.close()
 
 
-class Parameter(object):
-    '''
-    A parameter (common field of Input and Output) for a CommandLineTool
-    '''
-
-    def __init__(self, param_id, label=None, secondary_files=None, param_format=None,
-                 streamable=False, doc=None, param_type=None):
-        '''
-        :param param_id: unique identifier for this parameter
-        :type param_id: STRING
-        :param label: short, human-readable label
-        :type label: STRING
-        :param secondary_files: If type is a file, describes files that must be
-                                included alongside the primary file(s)
-        :type secondary_files: STRING
-        :param param_format: If type is a file, uri to ontology of the format or exact format
-        :type param_format: STRING
-        :param streamable: If type is a file, true indicates that the file is read or written
-                           sequentially without seeking
-        :type streamable: BOOLEAN
-        :param doc: documentation
-        :type doc: STRING
-        :param param_type: type of data assigned to the parameter
-        :type param_type: STRING corresponding to CWLType
-        '''
-        if param_type not in CWL_TYPE:
-            LOGGER.warning("The type is incorrect for the parameter.")
-            param_type = None
-        self.id = param_id
-        self.label = label
-        self.secondaryFiles = secondary_files
-        self.format = param_format
-        self.streamable = streamable
-        self.doc = doc
-        self.type = param_type
-
-    def get_dict(self):
-        '''
-        Transform the object to a [DICT] to write CWL.
-
-        :return: dictionnary of the object
-        :rtype: DICT
-        '''
-        dict_param = {k: v for k, v in vars(self).items() if v is not None and v is not False}
-        if dict_param['type'] != 'File':
-            # Remove what is only for File
-            for key in ['format', 'secondaryFiles', 'streamable']:
-               try:
-                   del(dict_param[key])
-               except KeyError:
-                   pass
-        return dict_param
 
 
 class CommandInputParameter(Parameter):

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -1,0 +1,66 @@
+
+
+#  Constant(s)  ------------------------------
+
+CWL_SHEBANG = "#!/usr/bin/env cwl-runner"
+CWL_VERSIONS = ['draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3',
+                'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1',
+                'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0', None]
+DEF_VERSION = 'v1.0'
+CWL_TYPE = ['null', 'boolean', 'int', 'long', 'float', 'double', 'string', 'File',
+            'Directory', None]
+
+
+
+class Parameter(object):
+    '''
+    Based class for parameters (common field of Input and Output) for CommandLineTool and Workflow
+    '''
+
+    def __init__(self, param_id, label=None, secondary_files=None, param_format=None,
+                 streamable=False, doc=None, param_type=None):
+        '''
+        :param param_id: unique identifier for this parameter
+        :type param_id: STRING
+        :param label: short, human-readable label
+        :type label: STRING
+        :param secondary_files: If type is a file, describes files that must be
+                                included alongside the primary file(s)
+        :type secondary_files: STRING
+        :param param_format: If type is a file, uri to ontology of the format or exact format
+        :type param_format: STRING
+        :param streamable: If type is a file, true indicates that the file is read or written
+                           sequentially without seeking
+        :type streamable: BOOLEAN
+        :param doc: documentation
+        :type doc: STRING
+        :param param_type: type of data assigned to the parameter
+        :type param_type: STRING corresponding to CWLType
+        '''
+        if param_type not in CWL_TYPE:
+            LOGGER.warning("The type is incorrect for the parameter.")
+            param_type = None
+        self.id = param_id
+        self.label = label
+        self.secondaryFiles = secondary_files
+        self.format = param_format
+        self.streamable = streamable
+        self.doc = doc
+        self.type = param_type
+
+    def get_dict(self):
+        '''
+        Transform the object to a [DICT] to write CWL.
+
+        :return: dictionnary of the object
+        :rtype: DICT
+        '''
+        dict_param = {k: v for k, v in vars(self).items() if v is not None and v is not False}
+        if dict_param['type'] != 'File':
+            # Remove what is only for File
+            for key in ['format', 'secondaryFiles', 'streamable']:
+               try:
+                   del(dict_param[key])
+               except KeyError:
+                   pass
+        return dict_param

--- a/cwlgen/import_cwl.py
+++ b/cwlgen/import_cwl.py
@@ -195,6 +195,7 @@ class CWLToolParser(object):
                 getattr(self, '_load_{}'.format(key))(tool, element)
             except AttributeError:
                 logger.warning(key + " content is not processed (yet).")
+        tool._path = cwl_path
         return tool
 
 def dict_or_idlist_items(v):
@@ -674,6 +675,7 @@ class CWLWorkflowParser(object):
                 getattr(self, '_load_{}'.format(key))(tool, element)
             except AttributeError:
                 logger.warning(key + " workflow content is not processed (yet).")
+        tool._path = cwl_path
         return tool
 
     def _load_id(self, tool, id_el):

--- a/cwlgen/workflow.py
+++ b/cwlgen/workflow.py
@@ -183,7 +183,7 @@ class StepRun:
         workflow.steps.append(step)
 
         for i, j in params.items():
-            if isinstance(j, basestring):
+            if isinstance(j, six.string_types):
                 step.inputs.append(WorkflowStepInput(i, default=j))
             elif isinstance(j, Variable):
                 step.inputs.append(WorkflowStepInput(i, src=j.path()))

--- a/test/test_unit_workflow.py
+++ b/test/test_unit_workflow.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+'''
+Unit tests for cwlgen library
+'''
+
+#  Import  ------------------------------
+
+# General libraries
+import os
+import filecmp
+import unittest
+
+# External libraries
+import cwlgen
+
+#  Class(es)  ------------------------------
+
+class TestCommandLineTool(unittest.TestCase):
+
+
+    def test_build(self):
+
+        w = cwlgen.Workflow()
+        tool = cwlgen.parse_cwl("test/import_cwl.cwl")
+
+        f = cwlgen.File("input_file")
+
+        o1 = w.add('step-a', tool, {"INPUT1" : f})
+        o2 = w.add('step-b', tool, {"INPUT1" : o1['OUTPUT1']})
+        o2['OUTPUT1'].store()
+        w.export("test.cwl")


### PR DESCRIPTION
Allows for a new workflow to be created easily using existing tools.

Example:
```
w = cwlgen.Workflow()
tool = cwlgen.parse_cwl("test/import_cwl.cwl")

f = cwlgen.File("input_file")

o1 = w.add('step-a', tool, {"INPUT1" : f})
o2 = w.add('step-b', tool, {"INPUT1" : o1['OUTPUT1']})
o2['OUTPUT1'].store()
w.export("test.cwl")
```

Produces the file
```
#!/usr/bin/env cwl-runner

class: Workflow
cwlVersion: v1.0
inputs:
  INPUT1: {id: INPUT1, type: File}
outputs:
  step-b_OUTPUT1: {id: step-b_OUTPUT1, outputSource: step-b/OUTPUT1, type: File}
steps:
  step-a:
    id: step-a
    in: {INPUT1: INPUT1}
    out: [OUTPUT1]
    run: test/import_cwl.cwl
  step-b:
    id: step-b
    in: {INPUT1: step-a/OUTPUT1}
    out: [OUTPUT1]
    run: test/import_cwl.cwl


```