### PR TITLE
Change default for glob to None from False

### DIFF
--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -279,7 +279,7 @@ class CommandOutputBinding(object):
     Describes how to generate an output parameter based on the files produced.
     '''
 
-    def __init__(self, glob=False, load_contents=False, output_eval=None):
+    def __init__(self, glob=None, load_contents=False, output_eval=None):
         '''
         :param glob: Find corresponding file(s)
         :type glob: STRING


### PR DESCRIPTION
Commit 69dc6a6475c40b613b9d1d93e3f55abe75f7d1fc changed the default for `glob` on CommandOutputBinding to be False instead of None, but it looks like a mistake - `glob` is a string, not a bool, and the similar `output_eval` defaults to None.