### PR TITLE
Optional types

### DIFF
--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -10,7 +10,7 @@ CWL_VERSIONS = ['draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3',
                 'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1',
                 'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0']
 DEF_VERSION = 'v1.0'
-NON_NONE_CWL_TYPE = ['boolean', 'int', 'long', 'float', 'double', 'string', 'File',
+NON_NULL_CWL_TYPE = ['boolean', 'int', 'long', 'float', 'double', 'string', 'File',
                      'Directory', 'stdout']
 CWL_TYPE = ['null', 'boolean', 'int', 'long', 'float', 'double', 'string', 'File',
             'Directory', 'stdout', None]
@@ -90,7 +90,7 @@ class Parameter(object):
             # Remove what is only for File
             for key in ['format', 'secondaryFiles', 'streamable']:
                 try:
-                    del (dict_param[key])
+                    del(dict_param[key])
                 except KeyError:
                     pass
         return dict_param

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -41,7 +41,7 @@ def parse_param_type(param_type):
             return DEF_TYPE
         return param_type
     else:
-        _LOGGER.warning("Unable to detect type of param '{param_type}", param_type)
+        _LOGGER.warning("Unable to detect type of param '{param_type}".format(param_type=param_type))
         return DEF_TYPE
 
 

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -1,0 +1,21 @@
+import unittest
+from cwlgen.elements import parse_param_type, NON_NONE_CWL_TYPE, CWL_TYPE, DEF_TYPE
+import logging
+
+
+class TestParamTyping(unittest.TestCase):
+
+    def test_types(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            self.assertEqual(parse_param_type(cwl_type), cwl_type)
+
+    def test_incorrect_type(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            should_be_def_type = parse_param_type(cwl_type.upper())
+            self.assertNotEqual(should_be_def_type, cwl_type)
+            self.assertEqual(should_be_def_type, DEF_TYPE)
+
+    def test_optional_string(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            optional_type = cwl_type + "?"
+            self.assertEqual(parse_param_type(optional_type), optional_type)

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -1,21 +1,21 @@
 import unittest
-from cwlgen.elements import parse_param_type, NON_NONE_CWL_TYPE, CWL_TYPE, DEF_TYPE
+from cwlgen.elements import parse_param_type, NON_NULL_CWL_TYPE, CWL_TYPE, DEF_TYPE
 import logging
 
 
 class TestParamTyping(unittest.TestCase):
 
     def test_types(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             self.assertEqual(parse_param_type(cwl_type), cwl_type)
 
     def test_incorrect_type(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             should_be_def_type = parse_param_type(cwl_type.upper())
             self.assertNotEqual(should_be_def_type, cwl_type)
             self.assertEqual(should_be_def_type, DEF_TYPE)
 
     def test_optional_string(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             optional_type = cwl_type + "?"
             self.assertEqual(parse_param_type(optional_type), optional_type)

--- a/test/test_unit_workflow.py
+++ b/test/test_unit_workflow.py
@@ -85,6 +85,33 @@ steps:
         generated = self.capture_tempfile(w.export)
         self.assertEqual(expected, generated)
 
+    def test_generates_workflow_optional_int_inputs(self):
+        w = cwlgen.Workflow()
+        # Use the same tool as the previous similar int_inputs
+        tool = cwlgen.parse_cwl("test/int_tool.cwl")
+
+        i = cwlgen.workflow.InputParameter('INTEGER', param_type='int?')
+        o1 = w.add('step', tool, {"INTEGER": i})
+        o1['OUTPUT1'].store()
+
+        expected = b"""#!/usr/bin/env cwl-runner
+
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  INTEGER: {id: INTEGER, type: int?}
+outputs:
+  step_OUTPUT1: {id: step_OUTPUT1, outputSource: step/OUTPUT1, type: File}
+steps:
+  step:
+    id: step
+    in: {INTEGER: INTEGER}
+    out: [OUTPUT1]
+    run: test/int_tool.cwl
+"""
+        generated = self.capture_tempfile(w.export)
+        self.assertEqual(expected, generated)
+
 
     def test_add_requirements(self):
         w = cwlgen.Workflow()

--- a/test/test_unit_workflow.py
+++ b/test/test_unit_workflow.py
@@ -85,34 +85,6 @@ steps:
         generated = self.capture_tempfile(w.export)
         self.assertEqual(expected, generated)
 
-    def test_generates_workflow_optional_int_inputs(self):
-        w = cwlgen.Workflow()
-        # Use the same tool as the previous similar int_inputs
-        tool = cwlgen.parse_cwl("test/int_tool.cwl")
-
-        i = cwlgen.workflow.InputParameter('INTEGER', param_type='int?')
-        o1 = w.add('step', tool, {"INTEGER": i})
-        o1['OUTPUT1'].store()
-
-        expected = b"""#!/usr/bin/env cwl-runner
-
-class: Workflow
-cwlVersion: v1.0
-inputs:
-  INTEGER: {id: INTEGER, type: int?}
-outputs:
-  step_OUTPUT1: {id: step_OUTPUT1, outputSource: step/OUTPUT1, type: File}
-steps:
-  step:
-    id: step
-    in: {INTEGER: INTEGER}
-    out: [OUTPUT1]
-    run: test/int_tool.cwl
-"""
-        generated = self.capture_tempfile(w.export)
-        self.assertEqual(expected, generated)
-
-
     def test_add_requirements(self):
         w = cwlgen.Workflow()
         req = cwlgen.InlineJavascriptReq()


### PR DESCRIPTION
My submission for #12 (no optional types), moves the type checking to separate function in preparation for checking arrays and other types referenced from the [CommandInputParameter documentation], (https://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter).