### PR TITLE
Adds CommandInputArraySchema and can check array types

### DIFF
--- a/cwlgen/__init__.py
+++ b/cwlgen/__init__.py
@@ -13,7 +13,7 @@ import six
 from .version import __version__
 
 from .utils import literal, literal_presenter
-from .elements import Parameter, CWL_VERSIONS, DEF_VERSION, CWL_SHEBANG
+from .elements import Parameter, CommandInputArraySchema, CWL_VERSIONS, DEF_VERSION, CWL_SHEBANG
 from .workflow import Workflow, File
 from .import_cwl import parse_cwl
 

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -129,8 +129,7 @@ class CommandInputArraySchema(object):
     def __init__(self, items=None, label=None, input_binding=None):
         '''
         :param items: Defines the type of the array elements.
-        :type: CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string |
-       array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>
+        :type: `CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string | array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>`
         :param label: A short, human-readable label of this object.
         :type label: STRING
         :param input_binding:

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -10,7 +10,7 @@ CWL_VERSIONS = ['draft-2', 'draft-3.dev1', 'draft-3.dev2', 'draft-3.dev3',
                 'draft-3.dev4', 'draft-3.dev5', 'draft-3', 'draft-4.dev1',
                 'draft-4.dev2', 'draft-4.dev3', 'v1.0.dev4', 'v1.0']
 DEF_VERSION = 'v1.0'
-NON_NONE_CWL_TYPE = ['boolean', 'int', 'long', 'float', 'double', 'string', 'File',
+NON_NULL_CWL_TYPE = ['boolean', 'int', 'long', 'float', 'double', 'string', 'File',
                      'Directory', 'stdout']
 CWL_TYPE = ['null', 'boolean', 'int', 'long', 'float', 'double', 'string', 'File',
             'Directory', 'stdout', None]
@@ -90,7 +90,7 @@ class Parameter(object):
             # Remove what is only for File
             for key in ['format', 'secondaryFiles', 'streamable']:
                 try:
-                    del (dict_param[key])
+                    del(dict_param[key])
                 except KeyError:
                     pass
         return dict_param

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -22,8 +22,9 @@ def parse_param_type(param_type):
     Parses the parameter type as one of the required types:
     :: https://www.commonwl.org/v1.0/CommandLineTool.html#CommandInputParameter
 
-
-    :param param_type:
+    :param param_type: a CWL type that is _validated_
+    :type param_type: CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string |
+       array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>
     :return: CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string |
        array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>
     """
@@ -117,10 +118,13 @@ class CommandInputArraySchema(object):
 
     def __init__(self, items=None, label=None, input_binding=None):
         '''
-
-        :param items:
-        :param label:
+        :param items: Defines the type of the array elements.
+        :type: CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string |
+       array<CWLType | CommandInputRecordSchema | CommandInputEnumSchema | CommandInputArraySchema | string>
+        :param label: A short, human-readable label of this object.
+        :type label: STRING
         :param input_binding:
+        :type input_binding: CommandLineBinding
         '''
         self.type = "array"
         self.items = parse_param_type(items)

--- a/cwlgen/elements.py
+++ b/cwlgen/elements.py
@@ -41,7 +41,7 @@ def parse_param_type(param_type):
             return DEF_TYPE
         return param_type
     else:
-        _LOGGER.warning("Unable to detect type of param '{param_type}", param_type)
+        _LOGGER.warning("Unable to detect type of param '{param_type}".format(param_type=param_type))
         return DEF_TYPE
 
 

--- a/doc/source/classes.rst
+++ b/doc/source/classes.rst
@@ -94,6 +94,15 @@ CommandOutputBinding
     :special-members:
     :exclude-members: __weakref__
 
+CommandInputArraySchema
+"""""""""""""""""""""""
+
+.. autoclass:: cwlgen.CommandInputArraySchema
+    :members:
+    :private-members:
+    :special-members:
+    :exclude-members: __weakref__
+
 .. _requirements:
 
 Requirements
@@ -137,7 +146,7 @@ CWLToolParser
     :private-members:
     :special-members:
     :exclude-members: __weakref_
-_
+
 InputsParser
 """"""""""""
 

--- a/test/test_unit_cwlgen.py
+++ b/test/test_unit_cwlgen.py
@@ -61,6 +61,10 @@ class TestParameter(unittest.TestCase):
         self.param = cwlgen.Parameter('an_id', param_type='File', label='a_label',\
                                      doc='a_doc', param_format='a_format',\
                                      streamable=True, secondary_files='sec_files')
+        self.nonfile_param = cwlgen.Parameter('non-file', param_type="string", label="a string",
+                                              streamable=True, secondary_files=[".txt"], doc="documentation here")
+
+        self.array_param = cwlgen.Parameter('an array', param_type='string[]', label="an array of strings")
 
     def test_init(self):
         self.assertEqual(self.param.id, 'an_id')
@@ -79,6 +83,21 @@ class TestParameter(unittest.TestCase):
         self.assertEqual(dict_test['label'], 'a_label')
         self.assertEqual(dict_test['secondaryFiles'], 'sec_files')
         self.assertTrue(dict_test['streamable'])
+
+    def test_nonfile_get_dict(self):
+        dict_test = self.nonfile_param.get_dict()
+        self.assertEqual(dict_test['type'], 'string')
+        self.assertEqual(dict_test['doc'], self.nonfile_param.doc)
+        self.assertNotIn('secondaryFiles', dict_test)
+        self.assertNotIn('streamable', dict_test)
+        self.assertNotIn('format', dict_test)
+
+    def test_array(self):
+        dict_test = self.array_param.get_dict()
+        td = dict_test['type']
+        self.assertIsInstance(td, dict)
+        self.assertEqual(td['type'], 'array')
+        self.assertEqual(td['items'], self.array_param.type.items)
 
 
 class TestCommandInputParameter(unittest.TestCase):

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -1,0 +1,21 @@
+import unittest
+from cwlgen.elements import parse_param_type, NON_NONE_CWL_TYPE, CWL_TYPE, DEF_TYPE
+import logging
+
+
+class TestParamTyping(unittest.TestCase):
+
+    def test_types(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            self.assertEqual(parse_param_type(cwl_type), cwl_type)
+
+    def test_incorrect_type(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            should_be_def_type = parse_param_type(cwl_type.upper())
+            self.assertNotEqual(should_be_def_type, cwl_type)
+            self.assertEqual(should_be_def_type, DEF_TYPE)
+
+    def test_optional_string(self):
+        for cwl_type in NON_NONE_CWL_TYPE:
+            optional_type = cwl_type + "?"
+            self.assertEqual(parse_param_type(optional_type), optional_type)

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -1,5 +1,5 @@
 import unittest
-from cwlgen.elements import parse_param_type, NON_NULL_CWL_TYPE, CWL_TYPE, DEF_TYPE
+from cwlgen.elements import parse_param_type, NON_NULL_CWL_TYPE, CWL_TYPE, DEF_TYPE, CommandInputArraySchema
 import logging
 
 
@@ -10,12 +10,53 @@ class TestParamTyping(unittest.TestCase):
             self.assertEqual(parse_param_type(cwl_type), cwl_type)
 
     def test_incorrect_type(self):
-        for cwl_type in NON_NULL_CWL_TYPE:
-            should_be_def_type = parse_param_type(cwl_type.upper())
-            self.assertNotEqual(should_be_def_type, cwl_type)
-            self.assertEqual(should_be_def_type, DEF_TYPE)
+        invalid_type = "invalid"
+        should_be_def_type = parse_param_type(invalid_type)
+        self.assertNotEqual(should_be_def_type, invalid_type)
+        self.assertEqual(should_be_def_type, DEF_TYPE)
 
     def test_optional_string(self):
         for cwl_type in NON_NULL_CWL_TYPE:
             optional_type = cwl_type + "?"
             self.assertEqual(parse_param_type(optional_type), optional_type)
+
+    def test_typed_array(self):
+        array_string_type = "string[]"
+        q = parse_param_type(array_string_type)
+        self.assertIsInstance(q, CommandInputArraySchema)
+        self.assertEqual(q.items, "string")
+
+    def test_incorrectly_typed_array(self):
+        array_string_type = "invalid[]"
+        q = parse_param_type(array_string_type)
+        self.assertIsInstance(q, CommandInputArraySchema)
+        self.assertNotEqual(q.items, "invalid")
+        self.assertEqual(q.items, DEF_TYPE)
+
+    def test_optionally_typed_array(self):
+        array_string_type = "string?[]"
+        q = parse_param_type(array_string_type)
+        self.assertIsInstance(q, CommandInputArraySchema)
+        self.assertEqual(q.items, "string?")
+
+    def test_optional_typed_array(self):
+        optional_array_string_type = "string[]?"
+        q = parse_param_type(optional_array_string_type)
+        self.assertIsInstance(q, list)
+        self.assertEqual(len(q), 2)
+        null_idx = q.index(DEF_TYPE)
+        array_type = q[1 - null_idx]
+        self.assertIsInstance(array_type, CommandInputArraySchema)
+        self.assertEqual(array_type.items, "string")
+
+    def test_command_input_array_schema(self):
+        ar = CommandInputArraySchema(items="string")
+        self.assertIsInstance(ar, CommandInputArraySchema)
+        self.assertEqual(parse_param_type(ar), ar)
+        self.assertEqual(ar.items, "string")
+
+    def test_optional_type_input_array_schema(self):
+        ar = CommandInputArraySchema(items="string?")
+        self.assertIsInstance(ar, CommandInputArraySchema)
+        self.assertEqual(parse_param_type(ar), ar)
+        self.assertEqual(ar.items, "string?")

--- a/test/test_unit_typing.py
+++ b/test/test_unit_typing.py
@@ -1,21 +1,21 @@
 import unittest
-from cwlgen.elements import parse_param_type, NON_NONE_CWL_TYPE, CWL_TYPE, DEF_TYPE
+from cwlgen.elements import parse_param_type, NON_NULL_CWL_TYPE, CWL_TYPE, DEF_TYPE
 import logging
 
 
 class TestParamTyping(unittest.TestCase):
 
     def test_types(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             self.assertEqual(parse_param_type(cwl_type), cwl_type)
 
     def test_incorrect_type(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             should_be_def_type = parse_param_type(cwl_type.upper())
             self.assertNotEqual(should_be_def_type, cwl_type)
             self.assertEqual(should_be_def_type, DEF_TYPE)
 
     def test_optional_string(self):
-        for cwl_type in NON_NONE_CWL_TYPE:
+        for cwl_type in NON_NULL_CWL_TYPE:
             optional_type = cwl_type + "?"
             self.assertEqual(parse_param_type(optional_type), optional_type)

--- a/test/test_unit_workflow.py
+++ b/test/test_unit_workflow.py
@@ -85,6 +85,33 @@ steps:
         generated = self.capture_tempfile(w.export)
         self.assertEqual(expected, generated)
 
+    def test_generates_workflow_optional_int_inputs(self):
+        w = cwlgen.Workflow()
+        # Use the same tool as the previous similar int_inputs
+        tool = cwlgen.parse_cwl("test/int_tool.cwl")
+
+        i = cwlgen.workflow.InputParameter('INTEGER', param_type='int?')
+        o1 = w.add('step', tool, {"INTEGER": i})
+        o1['OUTPUT1'].store()
+
+        expected = b"""#!/usr/bin/env cwl-runner
+
+class: Workflow
+cwlVersion: v1.0
+inputs:
+  INTEGER: {id: INTEGER, type: int?}
+outputs:
+  step_OUTPUT1: {id: step_OUTPUT1, outputSource: step/OUTPUT1, type: File}
+steps:
+  step:
+    id: step
+    in: {INTEGER: INTEGER}
+    out: [OUTPUT1]
+    run: test/int_tool.cwl
+"""
+        generated = self.capture_tempfile(w.export)
+        self.assertEqual(expected, generated)
+
 
     def test_add_requirements(self):
         w = cwlgen.Workflow()


### PR DESCRIPTION
Branched on the changes from #13, so that should be merged first. This change is my proposal for #14. 

I'm not super stoked with the placement of the class definition for `CommandInputArraySchema`, but without a major restructure not sure how I could reducer circular dependencies. My proposal for this would be to have a file for each type, and the way CWL is structured you shouldn't have any circular dependencies. This might help with adding to the Workflow conversion.