### PR TITLE
Ruamel update

### DIFF
--- a/doc/source/installation.rst
+++ b/doc/source/installation.rst
@@ -20,7 +20,7 @@ python-cwlgen dependencies
 
 python-cwlgen is initially built with Python3 and uses the following libraries:
 
-- ruamel.yaml (0.13.7)
+- ruamel.yaml (0.15.87)
 - six (1.10.0)
 
 .. _installation:

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name="cwlgen",
         author_email='kehillio@pasteur.fr',
         license='MIT',
         keywords = ['cwl'],
-        install_requires=['six', 'ruamel.yaml==0.13.13'],
+        install_requires=['six', 'ruamel.yaml==0.15.87'],
         packages=["cwlgen"],
         classifiers=[
             'Development Status :: 4 - Beta',


### PR DESCRIPTION
ruamel.yaml, which is used for the yaml parsing in cwlgen, will not install under python 3.7 because of an error in its setup.py.

This PR moves to the newest version of ruamel.yaml, (0.15.87) which does install okay.  The changes made to ruamel in that time do not seem to affect cwlgen, since they only modify cases where a YAML object is created, which is not done here.

The tests all still pass on my machine.

Cheers,
Joe