### PR TITLE
Add parsing of Requirements for Workflow / CommandLineTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,9 @@ with open("echotool.cwl", "w") as f:
 CWL is developed by an informal, multi-vendor working group consisting of organizations and individuals 
 aiming to enable scientists to share data analysis workflows. 
 The [CWL project is on Github](https://github.com/common-workflow-language/common-workflow-language).
+
+
+## Known issues
+
+- `SchemaDefRequirement` doesn't parse the `types` subfield into the specific types 
+(`InputRecordSchema | InputEnumSchema |  InputArraySchema`), but leaves them as a simple dictionary.

--- a/cwlgen/commandlinetool.py
+++ b/cwlgen/commandlinetool.py
@@ -41,7 +41,9 @@ class CommandInputParameter(Parameter):
     An input parameter for a :class:`cwlgen.CommandLineTool`.
     """
 
-    parse_types = [("inputBinding", [CommandLineBinding])]
+    parse_types = {
+        "inputBinding": [CommandLineBinding]
+    }
 
     def __init__(
         self,
@@ -96,7 +98,7 @@ class CommandOutputParameter(Parameter):
     An output parameter for a :class:`cwlgen.CommandLineTool`.
     """
 
-    parse_types = [("outputBinding", [CommandOutputBinding])]
+    parse_types = {"outputBinding": [CommandOutputBinding]}
 
     def __init__(
         self,
@@ -149,10 +151,10 @@ class CommandLineTool(Serializable):
 
     __CLASS__ = "CommandLineTool"
 
-    parse_types = [
-        ("inputs", [[CommandInputParameter]]),
-        ("outputs", [[CommandOutputParameter]]),
-    ]
+    parse_types = {
+        "inputs": [[CommandInputParameter]],
+        "outputs": [[CommandOutputParameter]],
+    }
     ignore_fields_on_parse = ["namespaces", "class"]
 
     def __init__(

--- a/cwlgen/import_cwl.py
+++ b/cwlgen/import_cwl.py
@@ -32,6 +32,11 @@ def parse_cwl(cwl_path):
     return parse_cwl_dict(cwl_dict)
 
 
+def parse_cwl_string(cwlstr):
+    cwl_dict = ryaml.load(cwlstr, Loader=ryaml.Loader)
+    return parse_cwl_dict(cwl_dict)
+
+
 def parse_cwl_dict(cwl_dict):
     cl = cwl_dict['class']
 

--- a/cwlgen/requirements.py
+++ b/cwlgen/requirements.py
@@ -196,15 +196,15 @@ class SchemaDefRequirement(Requirement):
         }
 
     parse_types = {
-        "types": [InputRecordSchema, InputEnumSchema, InputArraySchema],
+        # "types": [InputRecordSchema, InputEnumSchema, InputArraySchema],
     }
 
 
 # declare this here, because inside the InputArraySchema we haven't fully defined the schemas
-SchemaDefRequirement.InputArraySchema.parse_types = {
-    "items": [SchemaDefRequirement.InputRecordSchema, SchemaDefRequirement.InputEnumSchema,
-              SchemaDefRequirement.InputArraySchema, str]
-}
+# SchemaDefRequirement.InputArraySchema.parse_types = {
+#     "items": [SchemaDefRequirement.InputRecordSchema, SchemaDefRequirement.InputEnumSchema,
+#               SchemaDefRequirement.InputArraySchema, str]
+# }
 
 
 class SoftwareRequirement(Requirement):

--- a/cwlgen/utils.py
+++ b/cwlgen/utils.py
@@ -168,8 +168,8 @@ class Serializable(object):
             invalid_values = get_indices_of_element_in_list([False if v is None else True for v in retval], False)
             if invalid_values:
                 invalid_valuesstr = ','.join(str(i) for i in invalid_values)
-                raise Exception(f"Couldn't parse items at indices {invalid_valuesstr}, corresponding to: "
-                                + ", ".join([str(value[i]) for i in invalid_values]))
+                invalid_itemstr = ", ".join([str(value[i]) for i in invalid_values])
+                raise Exception("Couldn't parse items at indices " + invalid_valuesstr + ", corresponding to: " + invalid_itemstr)
             return retval
 
         for T in types:

--- a/cwlgen/utils.py
+++ b/cwlgen/utils.py
@@ -98,7 +98,7 @@ class Serializable(object):
         try:
             required_init_kwargs = T.get_required_input_params_for_cls(T, d)
             self = T(**required_init_kwargs)
-        except:
+        except Exception as e:
             return None
 
         for k, v in d.items():
@@ -168,8 +168,8 @@ class Serializable(object):
             invalid_values = get_indices_of_element_in_list([False if v is None else True for v in retval], False)
             if invalid_values:
                 invalid_valuesstr = ','.join(str(i) for i in invalid_values)
-                raise Exception(f"Couldn't parse items: {invalid_valuesstr}, corresponding to: "
-                                + ", ".join(str(value[i] for i in invalid_values)))
+                raise Exception(f"Couldn't parse items at indices {invalid_valuesstr}, corresponding to: "
+                                + ", ".join([str(value[i]) for i in invalid_values]))
             return retval
 
         for T in types:

--- a/cwlgen/workflow.py
+++ b/cwlgen/workflow.py
@@ -35,8 +35,8 @@ class Workflow(Serializable):
     Documentation: https://www.commonwl.org/v1.0/Workflow.html#Workflow
     """
     __CLASS__ = 'Workflow'
-    ignore_fields_on_parse = ["class"]
-    ignore_fields_on_convert = ["inputs", "outputs"]
+    ignore_fields_on_parse = ["class", "requirements"]
+    ignore_fields_on_convert = ["inputs", "outputs", "requirements"]
     parse_types = {
         "inputs": [[InputParameter]],
         "outputs": [[WorkflowOutputParameter]],
@@ -71,9 +71,6 @@ class Workflow(Serializable):
 
         cwl_workflow['class'] = self.__CLASS__
 
-        cwl_workflow['inputs'] = {}
-        cwl_workflow['outputs'] = {}
-
         # steps, inputs, outputs are required properties, so it should fail if we can't place it
         cwl_workflow['steps'] = {step.id: step.get_dict() for step in self.steps}
         cwl_workflow['inputs'] = {i.id: i.get_dict() for i in self.inputs}
@@ -93,7 +90,11 @@ class Workflow(Serializable):
             if isinstance(reqs, list):
                 wf.requirements = [Requirement.parse_dict(r) for r in reqs]
             elif isinstance(reqs, dict):
-                wf.requirements = [Requirement.parse_dict({**r, "class": c}) for c, r in reqs.items()]
+                # splat operator here would be so nice {**r, "class": c}
+                for c, r in reqs.items():
+                    rdict = {'class': c}
+                    rdict.update(r)
+                    wf.requirements.append(Requirement.parse_dict(rdict))
 
         return wf
 

--- a/cwlgen/workflowdeps.py
+++ b/cwlgen/workflowdeps.py
@@ -143,7 +143,9 @@ class WorkflowStep(Serializable):
     Documentation: https://www.commonwl.org/v1.0/Workflow.html#WorkflowStep
     """
 
-    parse_types = [("inputs", [[WorkflowStepInput]])]
+    parse_types = {
+        "inputs": [[WorkflowStepInput]]
+    }
 
     def __init__(self, step_id, run, label=None, doc=None, scatter=None, scatter_method=None):
         """

--- a/test/test_unit_import_tool.py
+++ b/test/test_unit_import_tool.py
@@ -182,9 +182,6 @@ requirements:
     SubworkflowFeatureRequirement: {}"""
         wf = parse_cwl_string(wfstr)
         self.assertEqual(3, len(wf.requirements))
-        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
-        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
-        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
 
         wfd = wf.get_dict()
         expected = {

--- a/test/test_unit_import_tool.py
+++ b/test/test_unit_import_tool.py
@@ -13,7 +13,8 @@ import unittest
 import ruamel.yaml as ryaml
 
 # External libraries
-from cwlgen.import_cwl import parse_cwl
+import cwlgen.requirements as Requirements
+from cwlgen.import_cwl import parse_cwl, parse_cwl_string
 
 #  Class(es)  ------------------------------
 
@@ -144,3 +145,51 @@ class TestOutputBindingParser(TestImport):
 
     def test_load_outputEval(self):
         self.assertEqual(self.tool.outputs[0].outputBinding.outputEval, "eval")
+
+
+class TestIntegrationImportWorkflow(unittest.TestCase):
+    def test_issue_25_requirements(self):
+        wfstr = """\
+class: CommandLineTool
+cwlVersion: v1.0
+
+requirements:
+  - class: MultipleInputFeatureRequirement
+  - class: StepInputExpressionRequirement
+  - class: SubworkflowFeatureRequirement"""
+        wf = parse_cwl_string(wfstr)
+        self.assertEqual(3, len(wf.requirements))
+        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
+        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
+        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
+
+        wfd = wf.get_dict()
+        expected = {
+            'MultipleInputFeatureRequirement': {},
+            'StepInputExpressionRequirement': {},
+            'SubworkflowFeatureRequirement': {}
+        }
+        self.assertDictEqual(expected, wfd["requirements"])
+
+    def test_issue_25_requirements_dict(self):
+        wfstr = """\
+class: CommandLineTool
+cwlVersion: v1.0
+
+requirements:
+    MultipleInputFeatureRequirement: {} 
+    StepInputExpressionRequirement: {}
+    SubworkflowFeatureRequirement: {}"""
+        wf = parse_cwl_string(wfstr)
+        self.assertEqual(3, len(wf.requirements))
+        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
+        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
+        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
+
+        wfd = wf.get_dict()
+        expected = {
+            'MultipleInputFeatureRequirement': {},
+            'StepInputExpressionRequirement': {},
+            'SubworkflowFeatureRequirement': {}
+        }
+        self.assertDictEqual(expected, wfd["requirements"])

--- a/test/test_unit_import_workflow.py
+++ b/test/test_unit_import_workflow.py
@@ -152,9 +152,6 @@ requirements:
     SubworkflowFeatureRequirement: {}"""
         wf = parse_cwl_string(wfstr)
         self.assertEqual(3, len(wf.requirements))
-        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
-        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
-        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
 
         wfd = wf.get_dict()
         expected = {

--- a/test/test_unit_import_workflow.py
+++ b/test/test_unit_import_workflow.py
@@ -13,7 +13,8 @@ from os import path
 import ruamel.yaml as ryaml
 
 # External libraries
-from cwlgen.import_cwl import parse_cwl_dict
+import cwlgen.requirements as Requirements
+from cwlgen.import_cwl import parse_cwl_dict, parse_cwl_string
 
 #  Class(es)  ------------------------------
 
@@ -109,3 +110,56 @@ class TestStepInputParser(TestImport):
     def test_load_source(self):
         self.assertEqual(self.wf.steps[0].inputs[0].source, "untar/extracted_file")
 
+
+class TestIntegrationImportWorkflow(unittest.TestCase):
+    def test_issue_25_requirements(self):
+        wfstr = """\
+class: Workflow
+cwlVersion: v1.0
+
+label: joint calling workflow
+doc: Perform joint calling on multiple sets aligned reads from the same family.
+
+requirements:
+  - class: MultipleInputFeatureRequirement
+  - class: StepInputExpressionRequirement
+  - class: SubworkflowFeatureRequirement"""
+        wf = parse_cwl_string(wfstr)
+        self.assertEqual(3, len(wf.requirements))
+        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
+        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
+        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
+
+        wfd = wf.get_dict()
+        expected = {
+            'MultipleInputFeatureRequirement': {},
+            'StepInputExpressionRequirement': {},
+            'SubworkflowFeatureRequirement': {}
+        }
+        self.assertDictEqual(expected, wfd["requirements"])
+
+    def test_issue_25_requirements_dict(self):
+        wfstr = """\
+class: Workflow
+cwlVersion: v1.0
+
+label: joint calling workflow
+doc: Perform joint calling on multiple sets aligned reads from the same family.
+
+requirements:
+    MultipleInputFeatureRequirement: {} 
+    StepInputExpressionRequirement: {}
+    SubworkflowFeatureRequirement: {}"""
+        wf = parse_cwl_string(wfstr)
+        self.assertEqual(3, len(wf.requirements))
+        self.assertIsInstance(wf.requirements[0], Requirements.MultipleInputFeatureRequirement)
+        self.assertIsInstance(wf.requirements[1], Requirements.StepInputExpressionRequirement)
+        self.assertIsInstance(wf.requirements[2], Requirements.SubworkflowFeatureRequirement)
+
+        wfd = wf.get_dict()
+        expected = {
+            'MultipleInputFeatureRequirement': {},
+            'StepInputExpressionRequirement': {},
+            'SubworkflowFeatureRequirement': {}
+        }
+        self.assertDictEqual(expected, wfd["requirements"])

--- a/test/test_unit_workflow.py
+++ b/test/test_unit_workflow.py
@@ -87,7 +87,7 @@ steps:
 
     def test_add_requirements(self):
         w = cwlgen.Workflow("test_add_requirements")
-        req = cwlgen.InlineJavascriptReq()
+        req = cwlgen.InlineJavascriptRequirement()
         w.requirements.append(req)
         generated = self.capture_tempfile(w.export)
         expected = b"""#!/usr/bin/env cwl-runner


### PR DESCRIPTION
Fixes #25 

Adds explicit parsing of the Requirements field for Workflow / CommandLineTool. 

It's doesn't work yet for InputRecordSchemaDef due to the way the parsing handles subtypes. In theory, you should be able to change L219 of utils.py to read (remove the `_generic for function`):

```python
return T.parse_dict(value) if not isinstance(value, list) else [T.parse_dict(vv) for vv in value]
```

But I'm getting a `parse_dict() missing 1 required positional argument: 'd'` or if I add the param I get a too many args exception. 