### PR TITLE
Add various fixes to cwlgen

### DIFF
--- a/cwlgen/commandlinetool.py
+++ b/cwlgen/commandlinetool.py
@@ -149,6 +149,7 @@ class CommandLineTool(Serializable):
 
     __CLASS__ = "CommandLineTool"
 
+    required_fields = ["inputs", "outputs"]
     parse_types = {'inputs': [[CommandInputParameter]], "outputs": [[CommandOutputParameter]]}
     ignore_fields_on_parse = ["namespaces", "class", "requirements"]
     ignore_fields_on_convert = ["namespaces", "class", "metadata", "requirements"]
@@ -159,7 +160,7 @@ class CommandLineTool(Serializable):
         base_command=None,
         label=None,
         doc=None,
-        cwl_version=None,
+        cwl_version="v1.0",
         stdin=None,
         stderr=None,
         stdout=None,
@@ -240,7 +241,9 @@ class CommandLineTool(Serializable):
 
         if "inputs" not in d:
             # Tool can have no inputs but still needs to be bound
-            d["inputs"] = []
+            d["inputs"] = {}
+        if "outputs" not in d:
+            d["outputs"] = {}
 
         if self.requirements:
             d["requirements"] = {r.get_class(): r.get_dict() for r in self.requirements}

--- a/cwlgen/commandlinetool.py
+++ b/cwlgen/commandlinetool.py
@@ -6,7 +6,7 @@ import ruamel.yaml
 from cwlgen.commandlinebinding import CommandLineBinding
 from .common import CWL_VERSIONS, DEF_VERSION, CWL_SHEBANG, Namespaces, Parameter
 from .requirements import *
-from .utils import literal, literal_presenter, Serializable
+from .utils import literal, literal_presenter, Serializable, value_or_default
 
 logging.basicConfig(level=logging.INFO)
 _LOGGER = logging.getLogger(__name__)
@@ -163,7 +163,12 @@ class CommandLineTool(Serializable):
         stdin=None,
         stderr=None,
         stdout=None,
-        path=None
+        path=None,
+        requirements=None,
+        hints=None,
+        inputs=None,
+        outputs=None,
+        arguments=None,
     ):
         """
         :param tool_id: Unique identifier for this tool
@@ -201,12 +206,12 @@ class CommandLineTool(Serializable):
         self.cwlVersion = cwl_version
         self.id = tool_id
         self.label = label
-        self.requirements = []  # List of objects inheriting from [Requirement]
-        self.hints = [] # List of objects inheriting from [Requirement]
-        self.inputs = []  # List of [CommandInputParameter] objects
-        self.outputs = []  # List of [CommandOutputParameter] objects
+        self.requirements = value_or_default(requirements, [])    # List of objects inheriting from [Requirement]
+        self.hints = value_or_default(hints, [])     # List of objects inheriting from [Requirement]
+        self.inputs = value_or_default(inputs, [])    # List of [CommandInputParameter] objects
+        self.outputs = value_or_default(outputs, [])      # List of [CommandOutputParameter] objects
         self.baseCommand = base_command
-        self.arguments = []  # List of [CommandLineBinding] objects
+        self.arguments = value_or_default(arguments, [])      # List of [CommandLineBinding] objects
         self.doc = doc
         self.stdin = stdin
         self.stderr = stderr

--- a/cwlgen/utils.py
+++ b/cwlgen/utils.py
@@ -225,3 +225,7 @@ def get_indices_of_element_in_list(searchable, element):
         if element == searchable[i]:
             indices.append(i)
     return indices
+
+
+def value_or_default(value, default):
+    return value if value is not None else default

--- a/cwlgen/utils.py
+++ b/cwlgen/utils.py
@@ -60,6 +60,8 @@ class Serializable(object):
     def get_dict(self):
         d = {}
         ignore_attributes = set()
+        req_fields = set(self.required_fields or [])
+
         if hasattr(self, "ignore_attributes") and self.ignore_attributes:
             ignore_attributes = set(self.ignore_attributes)
 
@@ -67,7 +69,14 @@ class Serializable(object):
             ignore_attributes = ignore_attributes.union(self.ignore_fields_on_convert)
 
         for k, v in vars(self).items():
-            if self.should_exclude_object(v) or k.startswith("_") or k in ignore_attributes or k == "ignore_attributes":
+            is_required = k in req_fields
+            should_skip = (
+                self.should_exclude_object(v)
+                or k.startswith("_")
+                or k in ignore_attributes
+                or k == "ignore_attributes"
+            )
+            if not is_required and should_skip:
                 continue
             s = self.serialize(v)
             if self.should_exclude_object(s):
@@ -115,7 +124,7 @@ class Serializable(object):
             req_fields = ", ".join(r for r in req if not req[r])
             clsname = T.__name__
 
-            raise Exception("The fields %s were not found when parsing type '%", format(req_fields, clsname))
+            raise Exception("The fields %s were not found when parsing type '%s'" % (req_fields, clsname))
 
         return self
 
@@ -159,7 +168,8 @@ class Serializable(object):
 
     @staticmethod
     def try_parse(value, types):
-        if not types: return value
+        if types is None: return value
+        if isinstance(value, (dict, list)) and len(value) == 0: return []
 
         # If it's an array, we should call try_parse (recursively)
 
@@ -176,6 +186,8 @@ class Serializable(object):
             retval = Serializable.try_parse_type(value, T)
             if retval:
                 return retval
+
+        return
 
 
     @staticmethod

--- a/cwlgen/workflow.py
+++ b/cwlgen/workflow.py
@@ -35,6 +35,7 @@ class Workflow(Serializable):
     Documentation: https://www.commonwl.org/v1.0/Workflow.html#Workflow
     """
     __CLASS__ = 'Workflow'
+    required_fields = ["inputs", "outputs", "steps"]
     ignore_fields_on_parse = ["class", "requirements"]
     ignore_fields_on_convert = ["inputs", "outputs", "requirements"]
     parse_types = {

--- a/cwlgen/workflow.py
+++ b/cwlgen/workflow.py
@@ -10,7 +10,7 @@ import six
 # Internal libraries
 
 from .requirements import Requirement
-from .utils import literal, literal_presenter, Serializable
+from .utils import literal, literal_presenter, Serializable, value_or_default
 from .common import Parameter, CWL_SHEBANG
 from .workflowdeps import InputParameter, WorkflowOutputParameter, WorkflowStep
 
@@ -43,7 +43,7 @@ class Workflow(Serializable):
         "steps": [[WorkflowStep]],
     }
 
-    def __init__(self, workflow_id=None, label=None, doc=None, cwl_version='v1.0'):
+    def __init__(self, workflow_id=None, label=None, doc=None, cwl_version='v1.0', inputs=None, outputs=None, steps=None, requirements=None, hints=None):
         """
         :param workflow_id: The unique identifier for this process object.
         :type workflow_id: STRING
@@ -59,11 +59,11 @@ class Workflow(Serializable):
         self.doc = doc
         self.cwlVersion = cwl_version
 
-        self.inputs = []            # list[InputParameter]
-        self.outputs = []           # list[WorkflowOutputParameter]
-        self.steps = []             # list[WorkflowStep]
-        self.requirements = []      # list[Requirement]
-        self.hints = []             # list[Requirement]
+        self.inputs = value_or_default(inputs, [])              # list[InputParameter]
+        self.outputs = value_or_default(outputs, [])            # list[WorkflowOutputParameter]
+        self.steps = value_or_default(steps, [])                # list[WorkflowStep]
+        self.requirements = value_or_default(requirements, [])  # list[Requirement]
+        self.hints = value_or_default(hints, [])                # list[Requirement]
         self._path = None
 
     def get_dict(self):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     long_description_content_type="text/markdown",
     license="MIT",
     keywords=["cwl"],
-    install_requires=["ruamel.yaml >= 0.12.4, < 0.16.6"],
+    install_requires=["ruamel.yaml >= 0.12.4, <= 0.16.5"],
     packages=["cwlgen"],
     classifiers=[
         "Development Status :: 4 - Beta",

--- a/test/test_export.py
+++ b/test/test_export.py
@@ -6,10 +6,26 @@ class TestExport(unittest.TestCase):
     def test_workflow_export(self):
         import cwlgen
         w = cwlgen.Workflow("identifier")
-        w.export()
+        expected = """\
+class: Workflow
+cwlVersion: v1.0
+id: identifier
+inputs: {}
+outputs: {}
+steps: {}
+"""
+        self.assertEqual(expected, w.export_string())
 
     def test_commandlinetool_export(self):
         import cwlgen
 
         c = cwlgen.CommandLineTool("identifier", "echo")
-        c.export()
+        expected = """\
+baseCommand: echo
+class: CommandLineTool
+cwlVersion: v1.0
+id: identifier
+inputs: {}
+outputs: {}
+"""
+        self.assertEqual(expected, c.export_string())

--- a/test/test_unit_import_tool.py
+++ b/test/test_unit_import_tool.py
@@ -153,6 +153,9 @@ class TestIntegrationImportWorkflow(unittest.TestCase):
 class: CommandLineTool
 cwlVersion: v1.0
 
+inputs: {}
+outputs: {}
+
 requirements:
   - class: MultipleInputFeatureRequirement
   - class: StepInputExpressionRequirement
@@ -175,6 +178,9 @@ requirements:
         wfstr = """\
 class: CommandLineTool
 cwlVersion: v1.0
+
+inputs: {}
+outputs: {}
 
 requirements:
     MultipleInputFeatureRequirement: {} 

--- a/test/test_unit_import_workflow.py
+++ b/test/test_unit_import_workflow.py
@@ -120,6 +120,10 @@ cwlVersion: v1.0
 label: joint calling workflow
 doc: Perform joint calling on multiple sets aligned reads from the same family.
 
+inputs: {}
+steps: {}
+outputs: {}
+
 requirements:
   - class: MultipleInputFeatureRequirement
   - class: StepInputExpressionRequirement
@@ -145,6 +149,10 @@ cwlVersion: v1.0
 
 label: joint calling workflow
 doc: Perform joint calling on multiple sets aligned reads from the same family.
+
+inputs: {}
+outputs: {}
+steps: {}
 
 requirements:
     MultipleInputFeatureRequirement: {} 


### PR DESCRIPTION
There are a few little niggles around that are easy to fix, just opening this PR to address some of those.

- Add required fields for workflow / commandline tool to ensure these are exported:
    - Closes: #45 
- Add more parameters (inputs, outputs, steps, etc) to Workflow and CommandLineTool for single line instantiation:
    - Closes: #34 
- Bumps ruamel.yaml range to match cwltool (https://github.com/common-workflow-language/cwltool/commit/b7aaee48019aaf50a05be6a4b3da51994163b5aa)
    - Supersedes: #42
